### PR TITLE
Change base dependency to support 4.7

### DIFF
--- a/inflections.cabal
+++ b/inflections.cabal
@@ -41,7 +41,7 @@ library
                        , Text.Inflections.Parse.CamelCase
 
   ghc-options:         -Wall
-  build-depends:       base >=4.5 && <4.7, parsec, containers
+  build-depends:       base >=4.5 && <4.8, parsec, containers
   default-language:    Haskell2010
 
 test-suite test
@@ -50,7 +50,7 @@ test-suite test
   main-is: Suite.hs
   build-depends:
       inflections
-      , base >=4.5 && <4.7
+      , base >=4.5 && <4.8
       , test-framework
       , HUnit
       , QuickCheck


### PR DESCRIPTION
This should fix #4
### Before

```
~/C/inflections-hs ❯❯❯ cabal install
Warning: /home/badosu/Code/inflections-hs/cabal.sandbox.config: Unrecognized
stanza on line 27
Resolving dependencies...
cabal: Could not resolve dependencies:
trying: HUnit-1.2.5.2/installed-e89... (user goal)
next goal: inflections (user goal)
rejecting: inflections-0.1.0.6 (conflict: HUnit =>
base==4.7.0.0/installed-018..., inflections => base>=4.5 && <4.7)
rejecting: inflections-0.1.0.5, 0.1.0.4, 0.1.0.3, 0.1.0.2, 0.1.0.1, 0.1.0.0
(global constraint requires ==0.1.0.6)
Dependency tree exhaustively searched.
Note: when using a sandbox, all packages are required to have consistent
dependencies. Try reinstalling/unregistering the offending packages or
recreating the sandbox.
```
### After

```
~/C/inflections-hs ❯❯❯ cabal --version
cabal-install version 1.20.0.1
using version 1.20.0.0 of the Cabal library
~/C/inflections-hs ❯❯❯ ghc --version
The Glorious Glasgow Haskell Compilation System, version 7.8.2
~/C/inflections-hs ❯❯❯ cabal test
Building inflections-0.1.0.6...
Preprocessing library inflections-0.1.0.6...
In-place registering inflections-0.1.0.6...
Preprocessing test suite 'test' for inflections-0.1.0.6...
Running 1 test suites...
Test suite test: RUNNING...
Test suite test: PASS
Test suite logged to: dist/test/inflections-0.1.0.6-test.log
1 of 1 test suites (1 of 1 test cases) passed.
~/C/inflections-hs ❯❯❯ cat dist/test/inflections-0.1.0.6-test.log
Test suite test: RUNNING...
dasherize:
  foo bar -> foo-bar: [OK]
transliterate:
  Without substitutions: [OK]
  With substitutions: [OK]
  Missing subs: [OK]
parameterize:
  Contains only valid chars: [OK, passed 100 tests]
  Does not begin with a separator character: [OK, passed 100 tests]
  Does not end in a separator character: [OK, passed 100 tests]
  All alphanumerics in input exist in output: [OK, passed 100 tests]
  Doesn't have subsequences of more than one hyphen: [OK, passed 100 tests]
underscore:
  testThis -> test_this: [OK]
ordinal:
  1 -> st: [OK]
  2 -> nd: [OK]
  1002 -> nd: [OK]
  1003 -> rd: [OK]
  -11 -> th: [OK]
  -1021 -> st: [OK]
  notEmpty: [OK, passed 100 tests]
ordinalize:
  1 -> st: [OK]
  -1021 -> st: [OK]
  result contains number: [OK, passed 100 tests]
humanize:
  employee_salary -> Employee salary: [OK]
  underground -> underground: [OK]
titleize:
  employee_salary -> Employee Salary: [OK]
  underground -> Underground: [OK]
         Properties  Test Cases   Total
 Passed  7           17           24
 Failed  0           0            0
 Total   7           17           24
Test suite test: PASS
```
