### PR TITLE
Add other-modules to tests test-suite

### DIFF
--- a/inflections.cabal
+++ b/inflections.cabal
@@ -60,3 +60,10 @@ test-suite test
       , containers
   ghc-options:         -Wall
   default-language:    Haskell2010
+  other-modules:
+    Text.InflectionsTest
+    Text.Inflections.HumanizeTest
+    Text.Inflections.OrdinalTest
+    Text.Inflections.Tests
+    Text.Inflections.TitleizeTest
+    Text.Inflections.UnderscoreTest


### PR DESCRIPTION
The tests test-suite didn't have a other-modules field, which means that the tar.gz in Hackage doesn't have all required files. See #10.