### PR TITLE
Relaxed Integer type

### DIFF
--- a/Text/Inflections/Ordinal.hs
+++ b/Text/Inflections/Ordinal.hs
@@ -21,7 +21,7 @@ where
 -- "nd"
 -- >>> ordinal 10
 -- "th"
-ordinal :: Integer -> String
+ordinal :: Integral a => a -> String
 ordinal number
         | remainder100 `elem` [11..13] = "th"
         | remainder10 == 1             = "st"
@@ -41,5 +41,5 @@ ordinal number
 -- "2nd"
 -- >>> ordinalize 10
 -- "10th"
-ordinalize :: Integer -> String
+ordinalize :: (Integral a, Show a) => a -> String
 ordinalize n = show n ++ ordinal n

--- a/inflections.cabal
+++ b/inflections.cabal
@@ -64,9 +64,9 @@ test-suite test
                      , hspec        >= 2.0   && < 3.0
                      , megaparsec   >= 5.0   && < 6.0
   if flag(dev)
-    ghc-options:      -Wall -Werror
+    ghc-options:      -Wall -Werror -fno-warn-type-defaults
   else
-    ghc-options:      -O2 -Wall
+    ghc-options:      -O2 -Wall -fno-warn-type-defaults
   default-language:    Haskell2010
   other-modules:       Text.Inflections.HumanizeSpec
                      , Text.Inflections.OrdinalSpec

--- a/inflections.cabal
+++ b/inflections.cabal
@@ -64,9 +64,9 @@ test-suite test
                      , hspec        >= 2.0   && < 3.0
                      , megaparsec   >= 5.0   && < 6.0
   if flag(dev)
-    ghc-options:      -Wall -Werror -fno-warn-type-defaults
+    ghc-options:      -Wall -Werror
   else
-    ghc-options:      -O2 -Wall -fno-warn-type-defaults
+    ghc-options:      -O2 -Wall
   default-language:    Haskell2010
   other-modules:       Text.Inflections.HumanizeSpec
                      , Text.Inflections.OrdinalSpec

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,5 @@
 resolver: lts-6.4
 packages:
 - '.'
+extra-deps:
+- megaparsec-5.0.0

--- a/test/Text/Inflections/OrdinalSpec.hs
+++ b/test/Text/Inflections/OrdinalSpec.hs
@@ -57,7 +57,7 @@ fullOrdinals = do
 ordinalReturnsNotEmpty :: Spec
 ordinalReturnsNotEmpty =
   it "never returns empty" $ property $
-    property <$> not . null . ordinal
+    property <$> not . null . (ordinal :: Integer -> String)
 
 ordinalizeContainsTheSameNumber :: Spec
 ordinalizeContainsTheSameNumber =

--- a/test/Text/Inflections/OrdinalSpec.hs
+++ b/test/Text/Inflections/OrdinalSpec.hs
@@ -26,33 +26,33 @@ spec = do
 one :: Spec
 one =
   it "returns the ordinal for 1" $
-    ordinal 1 `shouldBe` "st"
+    ordinal (1 :: Integer) `shouldBe` "st"
 
 two :: Spec
 two =
   it "returns the ordinal for 2" $
-    ordinal 2 `shouldBe` "nd"
+    ordinal (2 :: Integer) `shouldBe` "nd"
 
 thousands :: Spec
 thousands = do
   it "returns the ordinal for 1002" $
-    ordinal 1002 `shouldBe` "nd"
+    ordinal (1002 :: Integer) `shouldBe` "nd"
   it "returns the ordinal for 1003" $
-    ordinal 1003 `shouldBe` "rd"
+    ordinal (1003 :: Integer) `shouldBe` "rd"
 
 negatives :: Spec
 negatives = do
   it "returns the ordinal for -11" $
-    ordinal (-11) `shouldBe` "th"
+    ordinal (-11 :: Integer) `shouldBe` "th"
   it "returns the ordinal for -1021" $
-    ordinal (-1021) `shouldBe` "st"
+    ordinal (-1021 :: Integer) `shouldBe` "st"
 
 fullOrdinals :: Spec
 fullOrdinals = do
   it "returns the full ordinal for 1" $
-     ordinalize 1 `shouldBe` "1st"
+    ordinalize (1 :: Integer) `shouldBe` "1st"
   it "returns the full ordinal for -1021" $
-     ordinalize (-1021) `shouldBe` "-1021st"
+    ordinalize (-1021 :: Integer) `shouldBe` "-1021st"
 
 ordinalReturnsNotEmpty :: Spec
 ordinalReturnsNotEmpty =


### PR DESCRIPTION
I realized `ordinal` and `ordinalize` function take `Integer` value. So I have an error with below code.

```hs
$ ghci
> import Data.List
> import Text.Inflections
> ordinalize <$> elemIndex 5 [3..10]

<interactive>:7:16:
    Couldn't match type ‘Int’ with ‘Integer’
    Expected type: Maybe Integer
      Actual type: Maybe Int
    In the second argument of ‘(<$>)’, namely ‘elemIndex 5 [3 .. 10]’
    In the expression: ordinalize <$> elemIndex 5 [3 .. 10]
```

Actually, I can use `fromInteger`. But I think `Integral` type class is proper for these functions.