### PR TITLE
Allow Word to contain digits

### DIFF
--- a/Text/Inflections/Parse/CamelCase.hs
+++ b/Text/Inflections/Parse/CamelCase.hs
@@ -51,6 +51,6 @@ parser acronyms = many (acronym acronyms <|> word) <* eof
 word :: Parser Word
 word = do
   firstChar <- upperChar <|> lowerChar
-  restChars <- many lowerChar
+  restChars <- many $ lowerChar <|> digitChar
   return . Word . T.pack $ firstChar : restChars
 {-# INLINE word #-}

--- a/test/Text/InflectionsSpec.hs
+++ b/test/Text/InflectionsSpec.hs
@@ -7,9 +7,11 @@ import Text.Inflections (toUnderscore, toDashed, toCamelCased)
 
 spec :: Spec
 spec = do
-  describe "toUnderscore" $
+  describe "toUnderscore" $ do
     it "converts camel case to snake case" $
       toUnderscore "camelCasedText" `shouldReturn` "camel_cased_text"
+    it "converts camel case to snake case with numbers" $
+      toUnderscore "ipv4Address" `shouldReturn` "ipv4_address"
   describe "toDashed" $
     it "converts camel case to dashed" $
       toDashed "camelCasedText" `shouldReturn` "camel-cased-text"


### PR DESCRIPTION
I encountered an issue with `toUnderscore` function. It fails on the words that contain digits. 
I don't see any reasons against having digits in words (see test example), so the fix is pretty straightforward.