### PR TITLE
[#61] Change megaparsec version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Inflections 0.4.0.5
+* Support `megaparsec` == 8.0
+
 ## Inflections 0.4.0.3
 * Support `megaparsec` == 7.0*.
 * **Drop support** for `GHC 7.8.4`.

--- a/inflections.cabal
+++ b/inflections.cabal
@@ -1,5 +1,5 @@
 name:                inflections
-version:             0.4.0.4
+version:             0.4.0.5
 synopsis:            Inflections library for Haskell
 description:
   Inflections provides methods for singularization, pluralization,

--- a/inflections.cabal
+++ b/inflections.cabal
@@ -49,7 +49,7 @@ library
     ghc-options:      -O2 -Wall
   build-depends:       base         >= 4.6   && < 5.0
                      , exceptions   >= 0.6   && < 0.11
-                     , megaparsec   >= 7.0.1 && < 8.0
+                     , megaparsec   >= 7.0.1 && < 9.0
                      , text         >= 0.2   && < 1.3
                      , unordered-containers >= 0.2.7 && < 0.3
   if !impl(ghc >= 7.10)

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 resolver: lts-12.10
 
 extra-deps:
-  - hspec-megaparsec-2.0.0
+  - hspec-megaparsec-2.1.0
   - hspec-expectations-0.8.2
   - hspec-2.5.6
   - hspec-core-2.5.6
@@ -11,4 +11,4 @@ extra-deps:
   - HUnit-1.6.0.0
   - QuickCheck-2.12.2
   - quickcheck-io-0.2.0
-  - megaparsec-7.0.1
+  - megaparsec-8.0.0


### PR DESCRIPTION
This pull request addresses issue [#61 ]
It allows meparsec 8.0.0

