### PR TITLE
Bump bounds for ghc-9.6.1.

### DIFF
--- a/Text/Inflections/Ordinal.hs
+++ b/Text/Inflections/Ordinal.hs
@@ -9,6 +9,7 @@
 --
 -- Conversion to spelled ordinal numbers.
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Text.Inflections.Ordinal
@@ -16,7 +17,9 @@ module Text.Inflections.Ordinal
   , ordinal )
 where
 
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid ((<>))
+#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 

--- a/inflections.cabal
+++ b/inflections.cabal
@@ -50,7 +50,7 @@ library
   build-depends:       base         >= 4.11   && < 5.0
                      , exceptions   >= 0.6   && < 0.11
                      , megaparsec   >= 7.0.1 && < 10.0
-                     , text         >= 0.2   && < 1.3
+                     , text         >= 0.2   && < 2.1
                      , unordered-containers >= 0.2.7 && < 0.3
   if !impl(ghc >= 7.10)
     build-depends:      void         == 0.7.*
@@ -69,7 +69,7 @@ test-suite test
                      , hspec        >= 2.0   && < 3.0
                      , hspec-megaparsec >= 2.0 && < 3.0
                      , megaparsec
-                     , text         >= 0.2   && < 1.3
+                     , text         >= 0.2   && < 2.1
   if !impl(ghc >= 7.10)
     build-depends:      void         == 0.7.*
 

--- a/inflections.cabal
+++ b/inflections.cabal
@@ -1,3 +1,4 @@
+cabal-version:       2.0
 name:                inflections
 version:             0.4.0.6
 synopsis:            Inflections library for Haskell
@@ -14,7 +15,6 @@ maintainer:          Justin Leitgeb <justin@stackbuilders.com>
 copyright:           2014–2016 Justin Leitgeb
 category:            Text
 build-type:          Simple
-cabal-version:       >=1.10
 extra-source-files:  CHANGELOG.md
                    , README.md
 
@@ -61,7 +61,7 @@ test-suite test
   type: exitcode-stdio-1.0
   hs-source-dirs: test
   main-is: Spec.hs
-  build-tool-depends:  hspec-discover:hspec-discover >= 2.0 && < 3.0
+  build-tool-depends:  hspec-discover:hspec-discover
   build-depends:       inflections
                      , QuickCheck   >= 2.7.6 && < 3.0
                      , base         >= 4.11   && < 5.0


### PR DESCRIPTION
Bumped bounds so that this package compiles with `ghc-9.6.1` (I tested other versions too):

```
$ cabal test all
Resolving dependencies...
Build profile: -w ghc-9.6.1 -O1
In order, the following will be built (use -v for more details):
 - inflections-0.4.0.6 (lib) (first run)
 - inflections-0.4.0.6 (test:test) (first run)
Configuring library for inflections-0.4.0.6..
Preprocessing library for inflections-0.4.0.6..
Building library for inflections-0.4.0.6..
...
Running 1 test suites...
Test suite test: RUNNING...
Test suite test: PASS
Test suite logged to:
/.../dist-newstyle/build/x86_64-linux/ghc-9.6.1/inflections-0.4.0.6/t/test/test/inflections-0.4.0.6-test.log
1 of 1 test suites (1 of 1 test cases) passed.
```

Added `build-tool-depends` to avoid this error:

```
$ cabal build all --enable-tests --enable-benchmarks
Resolving dependencies...
Build profile: -w ghc-8.10.7 -O1
...
Configuring test suite 'test' for inflections-0.4.0.6..
Preprocessing test suite 'test' for inflections-0.4.0.6..
Building test suite 'test' for inflections-0.4.0.6..
ghc: could not execute: hspec-discover
```

Used a CPP conditional to avoid a `-Wunused-imports` warning:

```
Text/Inflections/Ordinal.hs:19:1: warning: [-Wunused-imports]
    The import of ‘Data.Monoid’ is redundant
      except perhaps to import instances from ‘Data.Monoid’
    To import instances alone, use: import Data.Monoid()
   |
19 | import Data.Monoid ((<>))
   | ^^^^^^^^^^^^^^^^^^^^^^^^^
```

From the [base changelog](https://hackage.haskell.org/package/base-4.18.0.0/changelog) this was added to the prelude in `base-4.11.0`.
