### PR TITLE
Bump bounds for ghc-9.6.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
         ghc:
           - "8.10"
           - "8.4.3"
+          - "9.6.1"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/Text/Inflections/Ordinal.hs
+++ b/Text/Inflections/Ordinal.hs
@@ -9,6 +9,7 @@
 --
 -- Conversion to spelled ordinal numbers.
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Text.Inflections.Ordinal
@@ -16,7 +17,9 @@ module Text.Inflections.Ordinal
   , ordinal )
 where
 
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid ((<>))
+#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 

--- a/inflections.cabal
+++ b/inflections.cabal
@@ -1,3 +1,4 @@
+cabal-version:       2.0
 name:                inflections
 version:             0.4.0.6
 synopsis:            Inflections library for Haskell
@@ -14,7 +15,6 @@ maintainer:          Justin Leitgeb <justin@stackbuilders.com>
 copyright:           2014–2016 Justin Leitgeb
 category:            Text
 build-type:          Simple
-cabal-version:       >=1.10
 extra-source-files:  CHANGELOG.md
                    , README.md
 
@@ -50,7 +50,7 @@ library
   build-depends:       base         >= 4.11   && < 5.0
                      , exceptions   >= 0.6   && < 0.11
                      , megaparsec   >= 7.0.1 && < 10.0
-                     , text         >= 0.2   && < 1.3
+                     , text         >= 0.2   && < 2.1
                      , unordered-containers >= 0.2.7 && < 0.3
   if !impl(ghc >= 7.10)
     build-depends:      void         == 0.7.*
@@ -61,7 +61,7 @@ test-suite test
   type: exitcode-stdio-1.0
   hs-source-dirs: test
   main-is: Spec.hs
-  build-tool-depends:  hspec-discover:hspec-discover >= 2.0 && < 3.0
+  build-tool-depends:  hspec-discover:hspec-discover
   build-depends:       inflections
                      , QuickCheck   >= 2.7.6 && < 3.0
                      , base         >= 4.11   && < 5.0
@@ -69,7 +69,7 @@ test-suite test
                      , hspec        >= 2.0   && < 3.0
                      , hspec-megaparsec >= 2.0 && < 3.0
                      , megaparsec
-                     , text         >= 0.2   && < 1.3
+                     , text         >= 0.2   && < 2.1
   if !impl(ghc >= 7.10)
     build-depends:      void         == 0.7.*
 


### PR DESCRIPTION
Same as #69 but solves merge issues and adds ghc 9.6.1 to github actions build