### PR TITLE
bump bounds for ghc-9.10

### DIFF
--- a/inflections.cabal
+++ b/inflections.cabal
@@ -51,7 +51,7 @@ library
   build-depends:       base         >= 4.11   && < 5.0
                      , exceptions   >= 0.6   && < 0.11
                      , megaparsec   >= 7.0.1 && < 10.0
-                     , text         >= 0.2   && < 2.1
+                     , text         >= 0.2   && < 2.2
                      , unordered-containers >= 0.2.7 && < 0.3
   if !impl(ghc >= 7.10)
     build-depends:      void         == 0.7.*
@@ -66,11 +66,11 @@ test-suite test
   build-depends:       inflections
                      , QuickCheck   >= 2.7.6 && < 3.0
                      , base         >= 4.11   && < 5.0
-                     , containers   >= 0.5   && < 0.7
+                     , containers   >= 0.5   && < 0.8
                      , hspec        >= 2.0   && < 3.0
                      , hspec-megaparsec >= 2.0 && < 3.0
                      , megaparsec
-                     , text         >= 0.2   && < 2.1
+                     , text         >= 0.2   && < 2.2
   if !impl(ghc >= 7.10)
     build-depends:      void         == 0.7.*
 


### PR DESCRIPTION
This should fix the build for the haskell-updates branch in nixpkgs:

```
Running phase: setupCompilerEnvironmentPhase
Build with /nix/store/a6ch4glhsgzpn9i9cqzpdlmbli5ylff7-ghc-9.10.2.
Running phase: unpackPhase
unpacking source archive /nix/store/pj7j6ksv1pmc6qwn91r6dy5ksw9wr7yg-inflections-0.4.0.7.tar.gz
source root is inflections-0.4.0.7
setting SOURCE_DATE_EPOCH to timestamp 1000000000 of file "inflections-0.4.0.7/Text/Inflections/Underscore.hs"
Running phase: patchPhase
Running phase: compileBuildDriverPhase
setupCompileFlags: -package-db=/build/tmp.dIJqRpSzfk/setup-package.conf.d -threaded
[1 of 2] Compiling Main             ( Setup.hs, /build/tmp.dIJqRpSzfk/Main.o )
[2 of 2] Linking Setup
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
configureFlags: --verbose --prefix=/nix/store/h9f80wpiicd310f5zdi1ma0piaxl5zny-inflections-0.4.0.7 --libdir=$prefix/lib/$compiler/lib --libsubdir=$abi/$libname --docdir=/nix/store/5fx89c1i2f4636lw6rckpxxc9gkll3f0-inflections-0.4.0.7-doc/share/doc/inflections-0.4.0.7 --with-gcc=gcc --package-db=/build/tmp.dIJqRpSzfk/package.conf.d --ghc-option=-j16 --ghc-option=+RTS --ghc-option=-A64M --ghc-option=-RTS --enable-library-profiling --profiling-detail=exported-functions --disable-profiling --enable-shared --disable-coverage --enable-static --disable-executable-dynamic --enable-tests --disable-benchmarks --enable-library-vanilla --disable-library-for-ghci --enable-split-sections --enable-library-stripping --enable-executable-stripping --ghc-option=-haddock --extra-lib-dirs=/nix/store/4kark163478mlnx42k2gakrji1z43z9m-ncurses-6.5/lib --extra-lib-dirs=/nix/store/qfz8slc34jinyfkvmskaplijj8a79w25-libffi-3.5.1/lib --extra-lib-dirs=/nix/store/qg2k9xl5af62zzlynwfim5f3ajwai88v-elfutils-0.193/lib --extra-lib-dirs=/nix/store/f6yc9mbdp17kh3p70lhlix1w21jlj5kp-gmp-with-cxx-6.3.0/lib --extra-lib-dirs=/nix/store/sbhy9snfwl00agyy54jra3k6il6s1rxh-numactl-2.0.18/lib
Using Parsec parser
Configuring inflections-0.4.0.7...
Error: [Cabal-8010]
Encountered missing or private dependencies:
    containers >=0.5 && <0.7, text >=0.2 && <2.1
CallStack (from HasCallStack):
  dieWithException, called at libraries/Cabal/Cabal/src/Distribution/Simple/Configure.hs:1457:11 in Cabal-3.12.1.0-8080:Distribution.Simple.Configure

```

https://github.com/NixOS/nixpkgs/pull/429810